### PR TITLE
Fix for loading sessions in Kitty

### DIFF
--- a/src/kitty.py
+++ b/src/kitty.py
@@ -198,7 +198,7 @@ class KiTTY(kp.Plugin):
             'enabled': given_enabled,
             'label': given_label,
             'exe_file': None,
-            'cmd_args': ['-load', '%1'],
+            'cmd_args': ['-kload', '%1'],
             'file_based': given_file_based,
             'sessions': []}
 


### PR DESCRIPTION
I was unable to get the sessions to load when typing `ssh<tab>session name<enter>`.  Looking at the documentation it appears that `-load` was incorrect.  It should've been `-kload`.  Please accept this pull request after testing.